### PR TITLE
Remove unused importlib.metadata for Python 3.7+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.7"
 docopt = "^0.6.2"
 rns = "^0.5.0" #{ git = "https://github.com/acehoss/Reticulum.git", branch = "feature/channel" }  #{ path = "../Reticulum/", develop = true }  #
 tomli = "^2.0.1"

--- a/rnsh/__init__.py
+++ b/rnsh/__init__.py
@@ -31,8 +31,8 @@ def _get_version():
             import tomli
             return tomli.load(open(os.path.join(os.path.dirname(module_dir), "pyproject.toml"), "rb"))["tool"]["poetry"]["version"]
         except:
-            from importlib.metadata import version
-            return version(__package__)
+            return "0.0.0"
+
     except:
         return "0.0.0"
 

--- a/rnsh/initiator.py
+++ b/rnsh/initiator.py
@@ -28,7 +28,6 @@ import asyncio
 import base64
 import enum
 import functools
-import importlib.metadata
 import logging as __logging
 import os
 import queue

--- a/rnsh/listener.py
+++ b/rnsh/listener.py
@@ -28,7 +28,6 @@ import asyncio
 import base64
 import enum
 import functools
-import importlib.metadata
 import logging as __logging
 import os
 import queue

--- a/rnsh/rnsh.py
+++ b/rnsh/rnsh.py
@@ -28,7 +28,6 @@ import asyncio
 import base64
 import enum
 import functools
-import importlib.metadata
 import logging as __logging
 import os
 import queue

--- a/tests/test_rnsh.py
+++ b/tests/test_rnsh.py
@@ -13,7 +13,6 @@ import os
 
 
 def test_version():
-    # version = importlib.metadata.version(rnsh.__version__)
     assert rnsh.__version__ != "0.0.0"
     assert rnsh.__version__ != "0.0.1"
 


### PR DESCRIPTION
Hi @acehoss

Would you consider merging these changes, thereby adding support for older versions of Python (3.7+)? I have quite a few old/odd systems running Python 3.7, and this makes `rnsh` work fine on them.

As far as I can see, there is no real functional reason for having `importlib.metadata` at this point, and I tested it all out on several systems already.