### PR TITLE
Missing version resolution

### DIFF
--- a/rnsh/__init__.py
+++ b/rnsh/__init__.py
@@ -31,7 +31,11 @@ def _get_version():
             import tomli
             return tomli.load(open(os.path.join(os.path.dirname(module_dir), "pyproject.toml"), "rb"))["tool"]["poetry"]["version"]
         except:
-            return "0.0.0"
+            try:
+                import pkg_resources
+                return pkg_resources.get_distribution("rnsh").version
+            except:
+                return "0.0.0"
 
     except:
         return "0.0.0"


### PR DESCRIPTION
Ok, sorry for the extra PR here, I was a bit too snappy, and didn't include a version resolution method for when the pyproject.toml file is not available, in which case the version would just be returned as `0.0.0`.

This PR fixes that.