### PR TITLE
Adaptive Compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ testconfig/
 /build/
 /dist/
 .pytest_cache/
+*__pycache__
+/RNS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 docopt = "^0.6.2"
-rns = "^0.5.3"
+rns = "^0.5.9"
 # rns = { git = "https://github.com/acehoss/Reticulum.git", branch = "feature/channel" }
 # rns = { path = "../Reticulum/", develop = true }
 tomli = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rnsh"
-version = "0.1.1"
+version = "0.1.2"
 description = "Shell over Reticulum"
 authors = ["acehoss <acehoss@acehoss.net>"]
 license = "MIT"

--- a/rnsh/initiator.py
+++ b/rnsh/initiator.py
@@ -279,7 +279,6 @@ async def initiate(configdir: str, identitypath: str, verbosity: int, quietness:
             nonlocal stdin_eof
             try:
                 data = process.tty_read(sys.stdin.fileno())
-                log.debug(f"stdin {data}")
                 if data is not None:
                     data_buffer.extend(data)
             except EOFError:

--- a/rnsh/process.py
+++ b/rnsh/process.py
@@ -525,7 +525,6 @@ class CallbackSubprocess:
         Write bytes to the stdin of the child process.
         :param data: bytes to write
         """
-        self._log.debug(f"write({data})")
         os.write(self._child_stdin, data)
 
     def set_winsize(self, r: int, c: int, h: int, v: int):


### PR DESCRIPTION
This PR implements adaptive compression for all data transfers. Since most interactive terminal data is easily compressible, this greatly improves performance over slower links.

Even when using `rnsh` for transferring non-terminal datastreams, this PR should improve performance and bandwidth utilisation in most cases.

![Figure_1](https://github.com/acehoss/rnsh/assets/1438012/eccad2cc-ec4f-4ad4-b6d5-29688a16f824)
*Scatter-plot of compressibility vs tries and time to success. Heat indicates chunk size.*

A representative sampling of 50.000 varied data-streams shows that the implemented methodology achieves high bandwidth savings within reasonable amounts of time (~3ms) for a significant amount of the stream chunks tested.

Almost all significant savings are found within 4 tries, and therefore the implementation has been capped at that amount of tries before data is sent uncompressed.

![Figure_2](https://github.com/acehoss/rnsh/assets/1438012/716f7f97-86e6-472e-a26d-9e9e3b6fffc9)
*Normalised distribution of tries required for successful chunk compression*

Since these changes rely on some under-the-hood additions to `StreamDataMessage` introduced in `RNS` version `0.5.9` (as of yet unreleased), I have bumped the required dependency version as well.

Please note that I have taken the liberty to include to log statement removals in this PR as well. I propose removing them, since they could inadverdently lead to users logging session I/O (think keystrokes) to a potential on-disk logfile, and at this point I believe it's better to not be able to accidentially to this. Feel free to revert those if I misunderstood something there!

Due to improvements in `RNS` in the upcoming release, it also seems that some of the strange behaviour and timeouts on packet loss, that did not recover, is now fixed.