### PR TITLE
Allowed Identities File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ testconfig/
 /build/
 /dist/
 .pytest_cache/
+*__pycache__
+/RNS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 docopt = "^0.6.2"
-rns = "^0.5.3"
+rns = "^0.5.9"
 # rns = { git = "https://github.com/acehoss/Reticulum.git", branch = "feature/channel" }
 # rns = { path = "../Reticulum/", develop = true }
 tomli = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rnsh"
-version = "0.1.1"
+version = "0.1.2"
 description = "Shell over Reticulum"
 authors = ["acehoss <acehoss@acehoss.net>"]
 license = "MIT"

--- a/rnsh/args.py
+++ b/rnsh/args.py
@@ -20,7 +20,7 @@ usage = \
 Usage:
     rnsh -l [-c <configdir>] [-i <identityfile> | -s <service_name>] [-v... | -q...] -p
     rnsh -l [-c <configdir>] [-i <identityfile> | -s <service_name>] [-v... | -q...] 
-            [-b <period>] (-n | -a <identity_hash> [-a <identity_hash>] ...) [-A | -C] 
+            [-b <period>] [-n] [-a <identity_hash>] ([-a <identity_hash>] ...) [-A | -C]
             [[--] <program> [<arg> ...]]
     rnsh [-c <configdir>] [-i <identityfile>] [-v... | -q...] -p
     rnsh [-c <configdir>] [-i <identityfile>] [-v... | -q...] [-N] [-m] [-w <timeout>] 
@@ -40,7 +40,9 @@ Options:
                                    user rnsh is running under will be used.
     -b --announce PERIOD         Announce on startup and every PERIOD seconds
                                  Specify 0 for PERIOD to announce on startup only.
-    -a HASH --allowed HASH       Specify identities allowed to connect
+    -a HASH --allowed HASH       Specify identities allowed to connect. Allowed identities
+                                   can also be specified in ~/.rnsh/allowed_identities or
+                                   ~/.config/rnsh/allowed_identities, one hash per line.
     -n --no-auth                 Disable authentication
     -N --no-id                   Disable identify on connect
     -A --remote-command-as-args  Concatenate remote command to argument list of <program>/shell

--- a/rnsh/initiator.py
+++ b/rnsh/initiator.py
@@ -279,7 +279,6 @@ async def initiate(configdir: str, identitypath: str, verbosity: int, quietness:
             nonlocal stdin_eof
             try:
                 data = process.tty_read(sys.stdin.fileno())
-                log.debug(f"stdin {data}")
                 if data is not None:
                     data_buffer.extend(data)
             except EOFError:

--- a/rnsh/process.py
+++ b/rnsh/process.py
@@ -525,7 +525,6 @@ class CallbackSubprocess:
         Write bytes to the stdin of the child process.
         :param data: bytes to write
         """
-        self._log.debug(f"write({data})")
         os.write(self._child_stdin, data)
 
     def set_winsize(self, r: int, c: int, h: int, v: int):

--- a/rnsh/rnsh.py
+++ b/rnsh/rnsh.py
@@ -117,7 +117,13 @@ async def _rnsh_cli_main():
         return 0
 
     if args.listen:
-        # log.info("command " + args.command)
+        allowed_file = None
+        dest_len = (RNS.Reticulum.TRUNCATED_HASHLENGTH//8)*2
+        if os.path.isfile(os.path.expanduser("~/.config/rnsh/allowed_identities")):
+            allowed_file = os.path.expanduser("~/.config/rnsh/allowed_identities")
+        elif os.path.isfile(os.path.expanduser("~/.rnsh/allowed_identities")):
+            allowed_file = os.path.expanduser("~/.rnsh/allowed_identities")
+
         await listener.listen(configdir=args.config,
                               command=args.command_line,
                               identitypath=args.identity,
@@ -125,6 +131,7 @@ async def _rnsh_cli_main():
                               verbosity=args.verbose,
                               quietness=args.quiet,
                               allowed=args.allowed,
+                              allowed_file=allowed_file,
                               disable_auth=args.no_auth,
                               announce_period=args.announce,
                               no_remote_command=args.no_remote_cmd,

--- a/rnsh/session.py
+++ b/rnsh/session.py
@@ -69,6 +69,7 @@ class LSOutletBase(ABC):
 class ListenerSession:
     sessions: List[ListenerSession] = []
     allowed_identity_hashes: [any] = []
+    allowed_file_identity_hashes: [any] = []
     allow_all: bool = False
     allow_remote_command: bool = False
     default_command: [str] = []
@@ -183,7 +184,7 @@ class ListenerSession:
         if self.state not in [LSState.LSSTATE_WAIT_IDENT, LSState.LSSTATE_WAIT_VERS]:
             self._protocol_error(LSState.LSSTATE_WAIT_IDENT.name)
 
-        if not self.allow_all and identity.hash not in self.allowed_identity_hashes:
+        if not self.allow_all and identity.hash not in self.allowed_identity_hashes and identity.hash not in self.allowed_file_identity_hashes:
             self.terminate("Identity is not allowed.")
 
         self.remote_identity = identity


### PR DESCRIPTION
This PR implements support for an `allowed_identities` file, located in either `~/.config/rnsh/` or `~/.rnsh`. Allowed identities from command line options will still be respected. The file is reloaded every time a new client link is established.

I'd also like to suggest moving the primary Identity file of `rnsh` into the config folder, alongside the `allowed_identities` file (and potential future config files). I have not implemented anything in this direction yet though, as I'm not sure whether you find it reasonable or not. So just a suggestion for future work :)