### PR TITLE
Escape Sequences, Session Termination & Line-Interactive Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ testconfig/
 /build/
 /dist/
 .pytest_cache/
+*__pycache__
+/RNS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 docopt = "^0.6.2"
-rns = "^0.5.9"
+rns = ">=0.5.9"
 # rns = { git = "https://github.com/acehoss/Reticulum.git", branch = "feature/channel" }
 # rns = { path = "../Reticulum/", develop = true }
 tomli = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 docopt = "^0.6.2"
-rns = "^0.5.3"
+rns = "^0.5.9"
 # rns = { git = "https://github.com/acehoss/Reticulum.git", branch = "feature/channel" }
 # rns = { path = "../Reticulum/", develop = true }
 tomli = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rnsh"
-version = "0.1.1"
+version = "0.1.2"
 description = "Shell over Reticulum"
 authors = ["acehoss <acehoss@acehoss.net>"]
 license = "MIT"

--- a/rnsh/args.py
+++ b/rnsh/args.py
@@ -20,7 +20,7 @@ usage = \
 Usage:
     rnsh -l [-c <configdir>] [-i <identityfile> | -s <service_name>] [-v... | -q...] -p
     rnsh -l [-c <configdir>] [-i <identityfile> | -s <service_name>] [-v... | -q...] 
-            [-b <period>] (-n | -a <identity_hash> [-a <identity_hash>] ...) [-A | -C] 
+            [-b <period>] [-n] [-a <identity_hash>] ([-a <identity_hash>] ...) [-A | -C]
             [[--] <program> [<arg> ...]]
     rnsh [-c <configdir>] [-i <identityfile>] [-v... | -q...] -p
     rnsh [-c <configdir>] [-i <identityfile>] [-v... | -q...] [-N] [-m] [-w <timeout>] 
@@ -40,7 +40,9 @@ Options:
                                    user rnsh is running under will be used.
     -b --announce PERIOD         Announce on startup and every PERIOD seconds
                                  Specify 0 for PERIOD to announce on startup only.
-    -a HASH --allowed HASH       Specify identities allowed to connect
+    -a HASH --allowed HASH       Specify identities allowed to connect. Allowed identities
+                                   can also be specified in ~/.rnsh/allowed_identities or
+                                   ~/.config/rnsh/allowed_identities, one hash per line.
     -n --no-auth                 Disable authentication
     -N --no-id                   Disable identify on connect
     -A --remote-command-as-args  Concatenate remote command to argument list of <program>/shell

--- a/rnsh/initiator.py
+++ b/rnsh/initiator.py
@@ -279,7 +279,6 @@ async def initiate(configdir: str, identitypath: str, verbosity: int, quietness:
             nonlocal stdin_eof
             try:
                 data = process.tty_read(sys.stdin.fileno())
-                log.debug(f"stdin {data}")
                 if data is not None:
                     data_buffer.extend(data)
             except EOFError:

--- a/rnsh/listener.py
+++ b/rnsh/listener.py
@@ -191,7 +191,6 @@ async def listen(configdir, command, identitypath=None, service_name=None, verbo
     def link_established(lnk: RNS.Link):
         _reload_allowed_file()
         session.ListenerSession.allowed_file_identity_hashes = _allowed_file_identity_hashes
-        print(str(_allowed_file_identity_hashes))
         session.ListenerSession(session.RNSOutlet.get_outlet(lnk), lnk.get_channel(), loop)
     _destination.set_link_established_callback(link_established)
 

--- a/rnsh/process.py
+++ b/rnsh/process.py
@@ -525,7 +525,6 @@ class CallbackSubprocess:
         Write bytes to the stdin of the child process.
         :param data: bytes to write
         """
-        self._log.debug(f"write({data})")
         os.write(self._child_stdin, data)
 
     def set_winsize(self, r: int, c: int, h: int, v: int):

--- a/rnsh/rnsh.py
+++ b/rnsh/rnsh.py
@@ -117,7 +117,13 @@ async def _rnsh_cli_main():
         return 0
 
     if args.listen:
-        # log.info("command " + args.command)
+        allowed_file = None
+        dest_len = (RNS.Reticulum.TRUNCATED_HASHLENGTH//8)*2
+        if os.path.isfile(os.path.expanduser("~/.config/rnsh/allowed_identities")):
+            allowed_file = os.path.expanduser("~/.config/rnsh/allowed_identities")
+        elif os.path.isfile(os.path.expanduser("~/.rnsh/allowed_identities")):
+            allowed_file = os.path.expanduser("~/.rnsh/allowed_identities")
+
         await listener.listen(configdir=args.config,
                               command=args.command_line,
                               identitypath=args.identity,
@@ -125,6 +131,7 @@ async def _rnsh_cli_main():
                               verbosity=args.verbose,
                               quietness=args.quiet,
                               allowed=args.allowed,
+                              allowed_file=allowed_file,
                               disable_auth=args.no_auth,
                               announce_period=args.announce,
                               no_remote_command=args.no_remote_cmd,

--- a/rnsh/session.py
+++ b/rnsh/session.py
@@ -69,6 +69,7 @@ class LSOutletBase(ABC):
 class ListenerSession:
     sessions: List[ListenerSession] = []
     allowed_identity_hashes: [any] = []
+    allowed_file_identity_hashes: [any] = []
     allow_all: bool = False
     allow_remote_command: bool = False
     default_command: [str] = []
@@ -183,7 +184,7 @@ class ListenerSession:
         if self.state not in [LSState.LSSTATE_WAIT_IDENT, LSState.LSSTATE_WAIT_VERS]:
             self._protocol_error(LSState.LSSTATE_WAIT_IDENT.name)
 
-        if not self.allow_all and identity.hash not in self.allowed_identity_hashes:
+        if not self.allow_all and identity.hash not in self.allowed_identity_hashes and identity.hash not in self.allowed_file_identity_hashes:
             self.terminate("Identity is not allowed.")
 
         self.remote_identity = identity


### PR DESCRIPTION
This PR implements `ssh`-style escape sessions for sending various control and session commands when inside a remote session. The escape sequence is identical to `ssh`. Pressing `~` immdiately after a newline, will bring the session into escape mode. Following up with `?` will display the quick reference, and thus all available escape sequences:

```
Supported rnsh escape sequences:
  ~~  Send the escape character by typing it twice
  ~.  Terminate session and exit immediately
  ~L  Toggle line-interactive mode
  ~?  Display this quick reference

(Escape sequences are only recognized immediately after newline)
```

Of note here is that it is now possible to easily terminate an unresponsive session with `~.`.

Another very useful feature that this PR implements is a line-interactive mode, that can be toggled with `~L`. In this mode, `rnsh` will buffer input until it can send a complete command (usually flushed by hitting enter, or a number of other "flush triggers"). The line-interactive mode tries to preserve console display, and features local echo when enabled. The logic behind this is still a bit rudimentary, but it works very well in most cases.

The line-interactive mode is **very** useful over extremely low-bandwidth links, where you don't want to ping-pong 4 packets back and forth every time a character is typed.

This PR, together with the adaptive compression PR, and the latest changes in `RNS` version `0.5.9`, makes it practically feasible run fully interactive remote sessions on remote system with `rnsh` over even the most low-bandwidth links that Reticulum supports.