### PR TITLE
Add support for dynamic link MTU discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rnsh"
-version = "0.1.4"
+version = "0.1.5"
 description = "Shell over Reticulum"
 authors = ["acehoss <acehoss@acehoss.net>"]
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-rns = ">=0.7.4"
+rns = ">=0.9.0"
 
 [tool.poetry.scripts]
 rnsh = 'rnsh.rnsh:rnsh_cli'

--- a/rnsh/initiator.py
+++ b/rnsh/initiator.py
@@ -448,21 +448,23 @@ async def initiate(configdir: str, identitypath: str, verbosity: int, quietness:
                         chunk_segment = None
 
                         chunk_segment = None
+                        max_data_len = channel.mdu - protocol.StreamDataMessage.OVERHEAD
                         while chunk_len > 32 and comp_try < comp_tries:
                             chunk_segment_length = int(chunk_len/comp_try)
                             compressed_chunk = bz2.compress(buf[:chunk_segment_length])
                             compressed_length = len(compressed_chunk)
-                            if compressed_length < protocol.StreamDataMessage.MAX_DATA_LEN and compressed_length < chunk_segment_length:
+                            if compressed_length < max_data_len and compressed_length < chunk_segment_length:
                                 comp_success = True
                                 break
                             else:
                                 comp_try += 1
 
                         if comp_success:
+                            diff = max_data_len - len(compressed_chunk)
                             chunk = compressed_chunk
                             processed_length = chunk_segment_length
                         else:
-                            chunk = bytes(buf[:protocol.StreamDataMessage.MAX_DATA_LEN])
+                            chunk = bytes(buf[:max_data_len])
                             processed_length = len(chunk)
 
                         return comp_success, processed_length, chunk

--- a/rnsh/session.py
+++ b/rnsh/session.py
@@ -218,21 +218,23 @@ class ListenerSession:
             chunk_segment = None
 
             chunk_segment = None
+            max_data_len = self.channel.mdu - protocol.StreamDataMessage.OVERHEAD
             while chunk_len > 32 and comp_try < comp_tries:
                 chunk_segment_length = int(chunk_len/comp_try)
                 compressed_chunk = bz2.compress(buf[:chunk_segment_length])
                 compressed_length = len(compressed_chunk)
-                if compressed_length < protocol.StreamDataMessage.MAX_DATA_LEN and compressed_length < chunk_segment_length:
+                if compressed_length < max_data_len and compressed_length < chunk_segment_length:
                     comp_success = True
                     break
                 else:
                     comp_try += 1
 
             if comp_success:
+                diff = max_data_len - len(compressed_chunk)
                 chunk = compressed_chunk
                 processed_length = chunk_segment_length
             else:
-                chunk = bytes(buf[:protocol.StreamDataMessage.MAX_DATA_LEN])
+                chunk = bytes(buf[:max_data_len])
                 processed_length = len(chunk)
 
             return comp_success, processed_length, chunk


### PR DESCRIPTION
This PR adds support for the dynamic link MTU discovery introduced in RNS 0.9.0, allowing `rnsh` to use higher packet MDUs on established links, leading to an increase in performance over mediums that support it.